### PR TITLE
fix #35: remove unused id_liste to set synthese autocomplete API

### DIFF
--- a/frontend/app/dashboard/dashboard-histogram/dashboard-histogram.component.html
+++ b/frontend/app/dashboard/dashboard-histogram/dashboard-histogram.component.html
@@ -110,7 +110,7 @@
                         </div>
                         <div id="taxon_filter" *ngIf="filter === 'Rechercher un taxon/une espèce...'">
                             <label class="col-form-label"> Taxon/espèce </label>
-                            <pnx-taxonomy label="" [parentFormControl]="histForm.controls.taxon" [idList]="500"
+                            <pnx-taxonomy label="" [parentFormControl]="histForm.controls.taxon"
                                 [charNumber]="3" [listLength]="30" [apiEndPoint]="taxonApiEndPoint"
                                 (onChange)="getCurrentTax($event)">
                             </pnx-taxonomy>

--- a/frontend/app/dashboard/dashboard-maps/dashboard-maps.component.html
+++ b/frontend/app/dashboard/dashboard-maps/dashboard-maps.component.html
@@ -171,7 +171,7 @@
                             <div class="col-md-6" id="taxon_filter"
                                 *ngIf="filter === 'Rechercher un taxon/une espèce...'">
                                 <label class="col-form-label"> Taxon/espèce </label>
-                                <pnx-taxonomy label="" [parentFormControl]="mapForm.controls.taxon" [idList]="500"
+                                <pnx-taxonomy label="" [parentFormControl]="mapForm.controls.taxon"
                                     [charNumber]="3" [listLength]="30" [apiEndPoint]="taxonApiEndPoint"
                                     (onChange)="getCurrentParameters($event)">
                                 </pnx-taxonomy>


### PR DESCRIPTION
fix #35 

En revanche, il semble persister un problème sur le filtrage par taxons de l'histogramme de synthèse par années. L'éxécution ne dépasse pas ce bloc... et n'aboutit pas avec ce message d'erreur. Peut-être un pb d'asynchrone

```
ERROR TypeError: can't access property "replace", taxon[_this.displayedLabel] is undefined
```

https://github.com/PnX-SI/gn_module_dashboard/blob/5c0928ca54bd54054073576d879c24c253f565ca/frontend/app/dashboard/dashboard-histogram/dashboard-histogram.component.ts#L166-L171