### PR TITLE
Dashboard doc : correction du cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ nécessaire de rafraichir régulièrement ces vues matérialisées. Pour cela
 vous pouvez mettre en place un CRON pour l'automatisation de cette
 tâche.
 
-Ouvrez le fichier `/etc/cron/geonature` s’il est existant, sinon créez le. Renseignez le commande `geonature dashboard refresh-vm`.
+Ouvrez le fichier `/etc/cron/geonature` s’il est existant, sinon créez le. Renseignez la commande `geonature dashboard refresh-vm`.
 
 ```
-0 0 * * 0 <UTLISATEUR LINUX GEONATURE> <CHEMIN_VERS_GEONATURE>/backend/venv/bin/geonature dashboard geonature dashboard refresh-vm
+0 0 * * 0 <UTLISATEUR LINUX GEONATURE> <CHEMIN_VERS_GEONATURE>/backend/venv/bin/geonature dashboard refresh-vm
 Exemple (exécuté tous les dimanches à 00h00):
-0 0 * * 0 geonatadmin /home/geonatadmin/backend/venv/bin/geonature geonature dashboard refresh-vm
+0 0 * * 0 su geonatadmin -c "/home/geonatadmin/geonature/backend/venv/bin/geonature dashboard refresh-vm"
 ```
 
 Cette commande peut être effectuée à tout moment depuis l’environnement


### PR DESCRIPTION
La commande proposée ne fonctionne pas sur mes instances. Il y a des erreurs de doublonnage et de chemin dans l'exemple proposé. La correction proposée fonctionne dans le crontab de l'utilisateur root. 
A noter que dans le cas du cron de l'utilisateur linux geonature lui même, il ne me semble pas nécessaire d'indiquer le nom de l'utilisateur. Ceci devrait fonctionner : 
 `0 0 * * 0 /home/geonatadmin/geonature/backend/venv/bin/geonature dashboard refresh-vm` 
Je n'ai pas testé car je centralise mes cron dans celui de l'utilisateur root pour n'en avoir qu'un mais la commande lancée directement en console fonctionne. 

Même principe ici https://github.com/PnX-SI/GeoNature/blob/master/docs/installation.rst pour l'automatisation de la mise à jour des profiles.